### PR TITLE
credential 수정, 컨트롤러 연결, swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation "io.springfox:springfox-swagger-ui:3.0.0"
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-web:2.7.5'
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.7.5'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/github/commitscrawler/config/DynamicCommitDetailCrawlerConfig.java
+++ b/src/main/java/com/github/commitscrawler/config/DynamicCommitDetailCrawlerConfig.java
@@ -2,6 +2,7 @@ package com.github.commitscrawler.config;
 
 import com.github.commitscrawler.crawler.CommitDetailCrawler;
 import com.github.commitscrawler.crawler.GitHtmlParser;
+import com.github.commitscrawler.parser.GitCommitHtmlParser;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,7 @@ public class DynamicCommitDetailCrawlerConfig implements BeanPostProcessor {
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
         if (bean instanceof CommitDetailCrawler && System.getenv().get("GIT_TOKEN") == null){
             System.out.println("GIT_TOKEN의 값이 NULL입니다. GitHtmlParser를 사용합니다.");
-            return new GitHtmlParser(WebClient.builder().baseUrl("https://github.com").build());
+            return new GitHtmlParser(WebClient.builder().baseUrl("https://github.com").build(), new GitCommitHtmlParser());
         }
         return bean;
     }

--- a/src/main/java/com/github/commitscrawler/config/SwaggerConfig.java
+++ b/src/main/java/com/github/commitscrawler/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.github.commitscrawler.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.github.commitscrawler"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/src/main/java/com/github/commitscrawler/context/googlesheets/GoogleSheetsReader.java
+++ b/src/main/java/com/github/commitscrawler/context/googlesheets/GoogleSheetsReader.java
@@ -17,10 +17,7 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.SheetsScopes;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,10 +27,10 @@ public class GoogleSheetsReader implements MemberReader {
 
     private static final String APPLICATION_NAME = "likelion-github-commits-crawler";
     private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
-    private static final String TOKENS_DIRECTORY_PATH = "tokens";
+    private static final String TOKENS_DIRECTORY_PATH = "google-sheets";
     private static final List<String> SCOPES =
             Collections.singletonList(SheetsScopes.SPREADSHEETS_READONLY);
-    private static final String CREDENTIALS_FILE_PATH = "/credential.json";
+    private static final String CREDENTIALS_FILE_PATH = "./google-sheets/credential.json";
     private final Parser<Member, List<Object>> parser;
 
     public GoogleSheetsReader(Parser<Member, List<Object>> parser) {
@@ -67,7 +64,7 @@ public class GoogleSheetsReader implements MemberReader {
 
     private static Credential getCredentials(final NetHttpTransport HTTP_TRANSPORT) throws IOException {
         // Load client secrets.
-        InputStream in = GoogleSheetsReader.class.getResourceAsStream(CREDENTIALS_FILE_PATH);
+        InputStream in = new FileInputStream(CREDENTIALS_FILE_PATH);
         if (in == null) {
             throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
         }

--- a/src/main/java/com/github/commitscrawler/controller/StudentProgressController.java
+++ b/src/main/java/com/github/commitscrawler/controller/StudentProgressController.java
@@ -3,6 +3,7 @@ package com.github.commitscrawler.controller;
 import com.github.commitscrawler.crawler.GitCommitCrawler;
 import com.github.commitscrawler.domain.commit.CommitPayload;
 import com.github.commitscrawler.lib.enumeration.Subject;
+import io.swagger.annotations.ApiParam;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +22,7 @@ public class StudentProgressController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<List<CommitPayload>> getList(@RequestParam("subject") String subjectName) {
+    public ResponseEntity<List<CommitPayload>> getList(@ApiParam(value = "과목 : algorithm / springboot") @RequestParam("subject") String subjectName) {
         // todo crawl한 List를 리턴함
         Subject subject = Subject.valueOf(subjectName.toUpperCase());
         return ResponseEntity.ok().body(gitCommitCrawler.getLatestCommitsAllMember(subject));

--- a/src/main/java/com/github/commitscrawler/controller/StudentProgressController.java
+++ b/src/main/java/com/github/commitscrawler/controller/StudentProgressController.java
@@ -1,22 +1,30 @@
 package com.github.commitscrawler.controller;
 
-import com.github.commitscrawler.domain.commit.CommitDetail;
+import com.github.commitscrawler.crawler.GitCommitCrawler;
+import com.github.commitscrawler.domain.commit.CommitPayload;
+import com.github.commitscrawler.lib.enumeration.Subject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/progress")
 public class StudentProgressController {
+    private final GitCommitCrawler gitCommitCrawler;
+
+    public StudentProgressController(GitCommitCrawler gitCommitCrawler) {
+        this.gitCommitCrawler = gitCommitCrawler;
+    }
 
     @GetMapping("/list")
-    public ResponseEntity<List<CommitDetail>> getList() {
+    public ResponseEntity<List<CommitPayload>> getList(@RequestParam("subject") String subjectName) {
         // todo crawl한 List를 리턴함
-        return ResponseEntity.ok().body(new ArrayList<>());
+        Subject subject = Subject.valueOf(subjectName.toUpperCase());
+        return ResponseEntity.ok().body(gitCommitCrawler.getLatestCommitsAllMember(subject));
     }
 
 }

--- a/src/main/java/com/github/commitscrawler/crawler/GitCommitCrawler.java
+++ b/src/main/java/com/github/commitscrawler/crawler/GitCommitCrawler.java
@@ -39,11 +39,10 @@ public class GitCommitCrawler {
 
                 // 멤버정보로 dto 생성.
                 CommitDetailRequest cdr = new CommitDetailRequest(gitUsername, repo);
-                CommitPayload payload = null;
+                CommitPayload payload = new CommitPayload(name);
 
                 try { // getLatestCommit() > commitDetailCrawler.crawlCommitDetail()에서의 예외 처리.
-                    payload = getLatestCommit(cdr);
-                    payload.setMemberName(name);
+                    payload.update(getLatestCommit(cdr));
                 } catch (RuntimeException e) {
                     System.out.println(e.getMessage());
                 }

--- a/src/main/java/com/github/commitscrawler/crawler/GitCommitCrawler.java
+++ b/src/main/java/com/github/commitscrawler/crawler/GitCommitCrawler.java
@@ -25,11 +25,11 @@ public class GitCommitCrawler {
         List<CommitPayload> payloads = members.stream()
                 .parallel()
                 .filter(member -> {
-                if (!member.isValid()) {
-                    System.out.printf("유효하지 않은 유저 정보입니다.\n%s\n", member);
-                    return false;
-                }
-                return true;
+                    if (!member.isValid()) {
+                        System.out.printf("유효하지 않은 유저 정보입니다.\n%s\n", member);
+                        return false;
+                    }
+                    return true;
                 }).map(member -> {
                 String name = member.getName();
                 String gitUsername = member.getGitUsername();

--- a/src/main/java/com/github/commitscrawler/domain/commit/CommitPayload.java
+++ b/src/main/java/com/github/commitscrawler/domain/commit/CommitPayload.java
@@ -1,16 +1,22 @@
 package com.github.commitscrawler.domain.commit;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.util.Date;
 
 @ToString
 @Getter
+@NoArgsConstructor
 public class CommitPayload {
     private String memberName;
     private String message;
     private Date push_at;
+
+    public CommitPayload(String memberName) {
+        this.memberName = memberName;
+    }
 
     public void setMemberName(String memberName) {
         this.memberName = memberName;
@@ -22,5 +28,18 @@ public class CommitPayload {
 
     public void setPush_at(Date push_at) {
         this.push_at = push_at;
+    }
+
+    public void update(CommitPayload commitPayload) {
+        updateMsg(commitPayload.getMessage());
+        updatePushAt(commitPayload.getPush_at());
+    }
+
+    private void updateMsg(String message) {
+        if (message != null) this.message = message;
+    }
+
+    private void updatePushAt(Date pushAt) {
+        if (pushAt != null) this.push_at =pushAt;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   profiles:
     active: local
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
 
 #git:
 #  token:


### PR DESCRIPTION
오류 수정
- block()/blockFirst()/blockLast() are blocking, which is not supported in thread reactor-http-nio-3 오류가 발생하여 dependency에 spring-boot-starter-web 추가했습니다.

git api 3xx, 4xx 발생 시
- commitPayload가 null로 반환되던 것을 학생이름만 담긴 commitPayload를 반환하게 수정하였습니다.

컨트롤러 연결
- subject를 쿼리로 입력받도록 연결하였습니다.
ref : #8 

Swagger 추가
- FE를 구현하기에는 부담스러워서 swagger 추가하였습니다.

Credential 수정
- 배포를 위해 credential 관련 파일의 위치와 값들을 수정했습니다.
- credential 파일 위치는 프로젝트 루트 폴더의 google-sheets 폴더 안에 넣는 것으로 수정했습니다.
ref : #12 